### PR TITLE
Added option to display report info without running the report

### DIFF
--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,0 +1,24 @@
+The MIT License
+
+Copyright (c) 2017 Rainforest Software Solution http://www.rainforestnet.com
+
+Permission is hereby granted, free of charge, 
+to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to 
+deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, 
+merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom 
+the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice 
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ The only mandatory argument is "-F", in which is for user to specify a Crystal R
 ### List of arguments
 
 * -F Crystal Reports filename to be loaded (i.e. "C:\Report Source\Report1.rpt") 
-* -O Crystal Reports Output filename (i.e. "C:\Reports Output\Report1.pdf" ) [Optional]
+* -O Output filename (i.e. "C:\Reports Output\Report1.pdf" ) [Optional]
 * -E Intended file format to be exported.(i.e. pdf, doc, xls .. and etc). If you wish to print Crystal Reports to a printer, simply "-E print" instead of specifying file format.
-
 * -N Printer Name. If printer name is not specified, it looks for default printer in the computer. If network printer, -N \\computer01\printer1
 * -C Number of copy to be printed (any integer value i.e. 1,2,3..)
 * -S Server Name for server where data resides. Only one server per Crystal Reports is allowed.
@@ -36,7 +35,8 @@ The only mandatory argument is "-F", in which is for user to specify a Crystal R
 * -U Data source / server login username. Do not specify username and password for Integrated Security connection.
 * -P Data source / server login password. Do not specify username and password for Integrated Security connection.
 * -a Pass Crystal Reports file parameter set on run-time
-* -l Create a log file into CrystalReportsNinja.exe directory
+* -L Create a log file into CrystalReportsNinja.exe directory
+* -I Display report info and quit
 
 ### -F, Crystal Reports source file
 This is the only mandatory (must specify) argument, it allows your to specify the Crystal Reports filename to be exported.
@@ -143,9 +143,10 @@ When we refresh a report, it prompts user to input the value of parameter in run
 
 You can pass parameter value to CrystalReportsNinja.exe when it is executed.
 
+### -I, Report Info
+Specifying this option will display information about the report and will not run the report (and as such Username, Server, Parameters, etc. are ignored). If -E is included, only the format TAB is implemented - any other option will display the human-readable format (just as if -E was not included). If -O is included the report information will not be displayed on the screen but will be output to the file specified. If that file doesn't exist it will be created and headers (if applicable) will be output first. If the file does exist it will be appended to (not clobbered), but headers will not be output.
 
-
-###Example 1
+### Example 1
 Let's take an example of a Crystal Reports file test.rpt located in C: root directory. The Crystal Reports file has two parameters, namely Supplier and Date Range.
 ```
 c:\>CrystalReportsNinja -U user1 -P mypass -S server1 -D Demo 
@@ -160,7 +161,7 @@ Use comma (,) to separate start value and end value of a Range parameter.
 Use pipe (|) to pass multiple values into the same parameter.
 Parameter name is case sensitive
 
-###Example 2
+### Example 2
 The following crystal Reports "testTraining.rpt" has 5 discrete parameters and 2 range parameters.
 Discrete parameters are:
 * company
@@ -192,4 +193,27 @@ Example to print Crystal Reports output to printer
 ```
 c:\>CrystalReportsNinja -F report101.rpt -E print -N "HP LaserJet 1200" -C 3
 ```
+
+### Example 3
+Let's again take an example of the test.rpt Crystal Report located in the C: root directory. This will display information about that report:
+```
+c:>\CrystalReportsNinja -F test.rpt -I
+```
+
+This would produce output similar to:
+
+```
+Report Name: Test Report
+File Name: rassdk://C:\test.rpt
+Connection #1:
+  Server Name: devsql01
+  Database Name: AdventureWorks
+  Integrated Security: No
+  Username: sa
+  Password: 
+Datasource #1:
+  Name: usp_GetTestData;1
+  Location: usp_GetTestData;1
+```
+
 

--- a/Source/CrystalReportsNinja.sln
+++ b/Source/CrystalReportsNinja.sln
@@ -11,12 +11,15 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A9BC6CCB-AFD4-4B80-BDE0-DBC99C8D51C2}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{A9BC6CCB-AFD4-4B80-BDE0-DBC99C8D51C2}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{A9BC6CCB-AFD4-4B80-BDE0-DBC99C8D51C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9BC6CCB-AFD4-4B80-BDE0-DBC99C8D51C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9BC6CCB-AFD4-4B80-BDE0-DBC99C8D51C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A9BC6CCB-AFD4-4B80-BDE0-DBC99C8D51C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E3D57891-BC27-4B30-AE6C-B10099F3A7C4}
 	EndGlobalSection
 EndGlobal

--- a/Source/CrystalReportsNinja/ArgumentContainer.cs
+++ b/Source/CrystalReportsNinja/ArgumentContainer.cs
@@ -62,14 +62,19 @@ namespace CrystalReportsNinja
         public int PrintCopy { get; set; }
         
         /// <summary>
-        /// -I Printer name
+        /// -N Printer name
         /// </summary>
         public string PrinterName { get; set; }
 
         /// To display Help message
         /// </summary>
         public bool GetHelp { get; set; }
-        
+
+        /// <summary>
+        /// -I report info only flag
+        /// </summary>
+        public bool ReportInfo { get; set; }
+
         /// <summary>
         /// To produce log file
         /// </summary>
@@ -95,6 +100,7 @@ namespace CrystalReportsNinja
             PrinterName = "";
             MailTo = "";
             Refresh = true;
+            ReportInfo = false;
 
             // Collection of string to store parameters
             ParameterCollection = new List<string>();
@@ -152,6 +158,9 @@ namespace CrystalReportsNinja
 
                 if (parameters[i].ToUpper() == "-NR")
                     Refresh = false;
+
+                if (parameters[i].ToUpper() == "-I")
+                    ReportInfo = true;
 
             }
             #endregion

--- a/Source/CrystalReportsNinja/CrystalReportsNinja.csproj
+++ b/Source/CrystalReportsNinja/CrystalReportsNinja.csproj
@@ -35,8 +35,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CrystalDecisions.CrystalReports.Engine, Version=13.0.2000.0, Culture=neutral, PublicKeyToken=692fbea5521e1304, processorArchitecture=MSIL" />
-    <Reference Include="CrystalDecisions.Shared, Version=13.0.2000.0, Culture=neutral, PublicKeyToken=692fbea5521e1304, processorArchitecture=MSIL" />
+    <Reference Include="CrystalDecisions.CrystalReports.Engine" />
+    <Reference Include="CrystalDecisions.Shared" />
+    <Reference Include="CrystalDecisions.Enterprise.InfoStore" />
+    <Reference Include="CrystalDecisions.Enterprise.Framework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/Source/CrystalReportsNinja/CrystalReportsNinja.csproj
+++ b/Source/CrystalReportsNinja/CrystalReportsNinja.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ParameterCore.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReportInfo.cs" />
     <Compile Include="ReportProcessor.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/CrystalReportsNinja/Helper.cs
+++ b/Source/CrystalReportsNinja/Helper.cs
@@ -24,16 +24,19 @@ namespace CrystalReportsNinja
             Console.WriteLine("-F Crystal reports path and filename (Mandatory)");
             Console.WriteLine("-S Database Server Name (instance name)");
             Console.WriteLine("-D Database Name");
-            Console.WriteLine("-O Crystal reports Output path and filename");
+            Console.WriteLine("-O Output path and filename");
             Console.WriteLine("-E Export file type.(pdf,doc,xls,rtf,htm,rpt,txt,csv...) If print to printer simply specify \"print\"");
             Console.WriteLine("-a Parameter value");
             Console.WriteLine("-N Printer Name (Network printer : \\\\PrintServer\\Printername or Local printer : printername)");
             Console.WriteLine("-C Number of copy to be printed");
-            Console.WriteLine("-l To write a log file. filename ninja-yyyyMMddHHmmss.log");
+            Console.WriteLine("-L To write a log file. filename ninja-yyyyMMddHHmmss.log");
+            Console.WriteLine("-I Display report info and quit. If supplied, -E only accepts \"print\" (i.e. human readable, the default) and tab");
             Console.WriteLine("---------------------------------------------------");
             Console.WriteLine("\nExample: C:\\> CrystalReportsNinja -U user1 -P mypass -S Server01 -D \"ExtremeDB\" -F c:\\test.rpt -O d:\\test.pdf -a \"Supplier Name:Active Outdoors\" -a \"Date Range:(12-01-2001,12-04-2002)\"");
-            Console.WriteLine("Learn more in http://www.rainforestnet.com/crystal-reports-exporter/");
-            
+            Console.WriteLine("Example: C:\\> CrystalReportsNinja -F c:\\test.rpt -I");
+            Console.WriteLine("Example: PoSH> ls C:\\ReportFolder -Filter *.rpt | % { CrystalReportsNinja -F $_.FullName -I -E tab -O C:\\ReportListing.tsv }");
+
+            Console.WriteLine("Learn more in https://github.com/rainforestnet/CrystalReportsNinja");
         }
 
         /// <summary>

--- a/Source/CrystalReportsNinja/Program.cs
+++ b/Source/CrystalReportsNinja/Program.cs
@@ -26,7 +26,15 @@ namespace CrystalReportsNinja
                         ReportArguments = argContainer,
                     };
 
-                    reportNinja.Run();
+                    if (argContainer.ReportInfo)
+                    {
+                        var reportInfo = reportNinja.GetReportInfo();
+                        reportInfo.Output(argContainer.OutputFormat, argContainer.OutputPath);
+                    }
+                    else
+                    {
+                        reportNinja.Run();
+                    }
                 }
             }
             catch (Exception ex)

--- a/Source/CrystalReportsNinja/ReportInfo.cs
+++ b/Source/CrystalReportsNinja/ReportInfo.cs
@@ -1,0 +1,204 @@
+﻿using CrystalDecisions.CrystalReports.Engine;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CrystalReportsNinja
+{
+    public class ReportInfo
+    {
+        #region Properties
+
+        public string ReportName { get; set; }
+        public string FileName { get; set; }
+        public ConnectionInfo[] Connections { get; set; }
+        public DatasourceInfo[] Datasources { get; set; }
+
+        public class ConnectionInfo
+        {
+            public string DatabaseName { get; set; }
+            public bool UsesIntegratedSecurity { get; set; }
+            public string ServerName { get; set; }
+            public string Username { get; set; }
+            public string Password { get; set; }
+        }
+
+        public class DatasourceInfo
+        {
+            public string Name { get; set; }
+            public string Location { get; set; }
+        }
+
+        #endregion
+
+        public ReportInfo(ReportDocument reportDocument)
+        {
+            ReportName = reportDocument.Name;
+            FileName = reportDocument.FileName;
+
+            Connections = new ConnectionInfo[reportDocument.DataSourceConnections.Count];
+            for (var i = 0; i < reportDocument.DataSourceConnections.Count; i++)
+            {
+                var conn = reportDocument.DataSourceConnections[i];
+                Connections[i] = new ConnectionInfo();
+                Connections[i].DatabaseName = conn.DatabaseName;
+                Connections[i].UsesIntegratedSecurity = conn.IntegratedSecurity;
+                Connections[i].ServerName = conn.ServerName;
+                Connections[i].Username = conn.UserID;
+                Connections[i].Password = conn.Password;
+            }
+
+            Datasources = new DatasourceInfo[reportDocument.Database.Tables.Count];
+            for (var i = 0; i < reportDocument.Database.Tables.Count; i++)
+            {
+                var table = reportDocument.Database.Tables[i];
+                Datasources[i] = new DatasourceInfo();
+                Datasources[i].Name = table.Name;
+                Datasources[i].Location = table.Location;
+            }
+        }
+
+        #region Output method & support
+
+        private const int MaxConnections = 2;
+        private const int MaxDatasources = 5;
+
+        public void Output(string outputFormat, string outputPath)
+        {
+            // Generate the output
+            var outBuffer = new StringBuilder();
+            switch ((outputFormat ?? "print").ToUpper())
+            {
+                case "TAB":
+                    outBuffer.AppendFormat("{0}\t", ReportName);
+                    outBuffer.AppendFormat("{0}\t", FileName);
+
+                    for (var i = 0; i < MaxConnections; i++)
+                    {
+                        ConnectionInfo conn = null;
+                        if (i < Connections.Length)
+                        {
+                            conn = Connections[i];
+                        }
+                        outBuffer.AppendFormat("{0}\t", conn?.ServerName);
+                        outBuffer.AppendFormat("{0}\t", conn?.DatabaseName);
+                        outBuffer.AppendFormat("{0}\t", conn == null ? "" : (conn.UsesIntegratedSecurity ? "Yes" : "No"));
+                        outBuffer.AppendFormat("{0}\t", conn?.Username);
+                        outBuffer.AppendFormat("{0}\t", conn?.Password);
+                    }
+
+
+                    for (var i = 0; i < MaxDatasources; i++)
+                    {
+                        DatasourceInfo datasource = null;
+                        if (i < Datasources.Length)
+                        {
+                            datasource = Datasources[i];
+                        }
+                        outBuffer.AppendFormat("{0}\t", datasource?.Name);
+                        outBuffer.AppendFormat("{0}\t", datasource?.Location);
+                    }
+
+                    // Remove the trailing \t and add an endline
+                    outBuffer.Length -= 1;
+                    outBuffer.AppendLine();
+                    break;
+                default:
+                    outBuffer.AppendFormat("Report Name: {0}\n", ReportName);
+                    outBuffer.AppendFormat("File Name: {0}\n", FileName);
+
+                    if (Connections.Length > 0)
+                    {
+                        for (var i = 0; i < Connections.Length; i++)
+                        {
+                            outBuffer.AppendFormat("Connection #{0}:\n", i + 1);
+                            var conn = Connections[i];
+                            outBuffer.AppendFormat("  Server Name: {0}\n", conn.ServerName);
+                            outBuffer.AppendFormat("  Database Name: {0}\n", conn.DatabaseName);
+                            outBuffer.AppendFormat("  Integrated Security: {0}\n", conn.UsesIntegratedSecurity ? "Yes" : "No");
+                            outBuffer.AppendFormat("  Username: {0}\n", conn.Username);
+                            outBuffer.AppendFormat("  Password: {0}\n", conn.Password);
+                        }
+                    }
+                    else
+                    {
+                        outBuffer.AppendFormat("No connections found\n");
+                    }
+
+                    if (Datasources.Length > 0)
+                    {
+                        for (var i = 0; i < Datasources.Length; i++)
+                        {
+                            outBuffer.AppendFormat("Datasource #{0}:\n", i + 1);
+                            var datasource = Datasources[i];
+                            outBuffer.AppendFormat("  Name: {0}\n", datasource.Name);
+                            outBuffer.AppendFormat("  Location: {0}\n", datasource.Location);
+                        }
+                    }
+                    else
+                    {
+                        outBuffer.AppendFormat("No datasources found\n");
+                    }
+
+                    break;
+            }
+
+            // Output the, uh, output
+            if (string.IsNullOrEmpty(outputPath))
+            {
+                Console.Write(outBuffer.ToString());
+            }
+            else
+            {
+                if (!File.Exists(outputPath))
+                {
+                    File.WriteAllText(outputPath, GetHeader(outputFormat));
+                }
+
+                using (var strm = File.AppendText(outputPath))
+                {
+                    strm.Write(outBuffer.ToString());
+                }
+            }
+        }
+
+        private string GetHeader(string outputFormat)
+        {
+            var outBuffer = new StringBuilder();
+            switch ((outputFormat ?? "print").ToUpper())
+            {
+                case "TAB":
+                    outBuffer.AppendFormat("Report Name\t", ReportName);
+                    outBuffer.AppendFormat("Report File Name\t", FileName);
+
+                    for (var i = 0; i < MaxConnections; i++)
+                    {
+                        outBuffer.AppendFormat("Conn {0}: Server\t", i + 1);
+                        outBuffer.AppendFormat("Conn {0}: Database\t", i + 1);
+                        outBuffer.AppendFormat("Conn {0}: Integrated Security\t", i + 1);
+                        outBuffer.AppendFormat("Conn {0}: Username\t", i + 1);
+                        outBuffer.AppendFormat("Conn {0}: Password\t", i + 1);
+                    }
+
+                    for (var i = 0; i < 5; i++)
+                    {
+                        outBuffer.AppendFormat("Datasource {0}: Name\t", i + 1);
+                        outBuffer.AppendFormat("Datasource {0}: Location\t", i + 1);
+                    }
+
+                    // Remove the trailing \t and add an endline
+                    outBuffer.Length -= 1;
+                    outBuffer.AppendLine();
+                    break;
+            }
+
+            return outBuffer.ToString();
+        }
+
+        #endregion
+    }
+}
+

--- a/Source/CrystalReportsNinja/ReportProcessor.cs
+++ b/Source/CrystalReportsNinja/ReportProcessor.cs
@@ -44,8 +44,10 @@ namespace CrystalReportsNinja
                 throw new Exception("Invalid Crystal Reports file");
 
             _reportDoc.Load(_sourceFilename, OpenReportMethod.OpenReportByDefault);
-            _logger.Write(string.Format("Report loaded successfully"));
-            Console.WriteLine("Report loaded successfully");
+
+            var filenameOnly = System.IO.Path.GetFileNameWithoutExtension(_sourceFilename);
+            _logger.Write(string.Format("Report {0} loaded successfully", filenameOnly));
+            Console.WriteLine("Report {0} loaded successfully", filenameOnly);
         }
 
         /// <summary>
@@ -299,6 +301,30 @@ namespace CrystalReportsNinja
 
                 PerformRefresh();
                 PerformOutput();
+            }
+            catch (Exception ex)
+            {
+                _logger.Write(string.Format("Exception: {0}", ex.Message));
+                _logger.Write(string.Format("Inner Exception: {0}", ex.InnerException));
+
+                throw ex;
+            }
+            finally
+            {
+                _reportDoc.Close();
+            }
+        }
+
+        /// <summary>
+        /// Collect and return the Crystal Reports data connection info.
+        /// </summary>
+        public ReportInfo GetReportInfo()
+        {
+            try
+            {
+                LoadReport();
+                var reportInfo = new ReportInfo(_reportDoc);
+                return reportInfo;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Added a parameter to allow simple metadata extraction from the report files. Also implemented enough of output and export format parameters to allow for a bulk extraction of multiple report files.

The metadata return includes report name, database connection information, and datasource (stored procedure) information.
